### PR TITLE
Changed the way $.each behaves with arrays and array-like objects.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -164,7 +164,7 @@ tire.fn = tire.prototype = {
 
     if (target === this || target instanceof Array) {
       for (i = 0; i < target.length; ++i) {
-        if (callback.call(target[i], target[i], i, target) === false) break;
+        if (callback.call(target[i], i, target[i], target) === false) break;
       }
     } else {
       for (key in target) {
@@ -205,7 +205,7 @@ tire.extend = function () {
 
   if (arguments.length === 1) target = this;
 
-  tire.fn.each(slice.call(arguments), function (value) {
+  tire.fn.each(slice.call(arguments), function (index, value) {
     for (var key in value) {
       if (target[key] !== value[key]) target[key] = value[key];
     }

--- a/src/fn/attributes.js
+++ b/src/fn/attributes.js
@@ -8,7 +8,7 @@ tire.fn.extend({
 
   addClass: function (value) {
     if (value && tire.isString(value)) {
-      return this.each(function (elm) {
+      return this.each(function (index, elm) {
         if (elm.nodeType === 1) {
           var classNames = value.split(/\s+/);
           if (!elm.className && classNames.length === 1) {
@@ -36,7 +36,7 @@ tire.fn.extend({
    */
 
   removeClass: function (value) {
-    return this.each(function (elm) {
+    return this.each(function (index, elm) {
       if (value && tire.isString(value)) {
         var classNames = value.split(/\s+/);
         if (elm.nodeType === 1 && elm.className) {

--- a/src/fn/dom.js
+++ b/src/fn/dom.js
@@ -16,7 +16,7 @@ var domReady = (function () {
       scrollCheck();
     }
   }
-  
+
   function done () {
     if (addEventListener) {
       document.removeEventListener('DOMContentLoaded', done, false);
@@ -69,11 +69,11 @@ tire.fn.extend({
    * @param {String|Object} selector The selector match
    * @return {Boolean}
    */
-   
+
   is: function (selector) {
     return this.length > 0 && tire.matches(this[0], selector);
   },
-  
+
   /**
    * Get the first element that matches the selector, beginning at the current element and progressing up through the DOM tree.
    *
@@ -81,18 +81,18 @@ tire.fn.extend({
    * @param {Object} context
    * @return {Object}
    */
-    
+
   closest: function (selector, context) {
     var node = this[0];
-      
+
     while (node && !tire.matches(node, selector)) {
       node = node.parentNode;
       if (!node || !node.ownerDocument || node === context || node.nodeType === 11) break;
     }
-    
+
     return tire(node);
   },
-  
+
   /**
    * Get immediate parents of each element in the collection.
    * If CSS selector is given, filter results to include only ones matching the selector.
@@ -100,12 +100,12 @@ tire.fn.extend({
    * @param {String} selector
    * @return {Object}
    */
-  
+
   parent: function (selector) {
     var parent = this.pluck('parentNode');
     return selector === undefined ? tire(parent) : tire(parent).filter(selector);
   },
-  
+
   /**
    * Get immediate children of each element in the current collection.
    * If selector is given, filter the results to only include ones matching the CSS selector.
@@ -113,11 +113,11 @@ tire.fn.extend({
    * @param {String} selector
    * @return {Object}
    */
-  
+
   children: function (selector) {
     var children = [];
     this.each(function () {
-      tire.each(tire.slice.call(this.children, 0), function (value) {
+      tire.each(tire.slice.call(this.children, 0), function (index, value) {
         children.push(value);
       });
     });
@@ -133,7 +133,7 @@ tire.fn.extend({
    * @param {String} text
    * @return {Object|String}
    */
-   
+
   text: function (text) {
     if (text === undefined) {
       return this.length > 0 ? this[0].textContent : null;
@@ -143,7 +143,7 @@ tire.fn.extend({
       });
     }
   },
-  
+
   /**
    * Get value for input/select elements
    * Set value for input/select elements
@@ -151,7 +151,7 @@ tire.fn.extend({
    * @param {String} value
    * @return {Object|String}
    */
-  
+
   val: function (value) {
     if (!arguments.length) {
       if (this.length > 0) {
@@ -159,7 +159,7 @@ tire.fn.extend({
           return this.selected;
         }).pluck('value') : this[0].value;
       }
-      
+
       return null;
     } else {
       return this.each(function () {
@@ -174,19 +174,19 @@ tire.fn.extend({
       });
     }
   },
-  
+
   /**
    * Empty `innerHTML` for elements
    *
    * @return {Object}
    */
-  
+
   empty: function () {
     return this.each(function () {
       this.innerHTML = '';
     });
   },
-  
+
   /**
    * Get html for the first element in the collection
    * Set html for every elements in the collection
@@ -195,12 +195,12 @@ tire.fn.extend({
    * @param {String} location
    * @return {String|Object}
    */
-  
+
   html: function (html, location) {
     if (arguments.length === 0) {
       return this.length > 0 ? this[0].innerHTML : null;
     }
-        
+
     location = location || 'inner';
 
     if (html instanceof tire) html = html[0];
@@ -219,7 +219,7 @@ tire.fn.extend({
         var wrapped  = wrap(html)
           , children = wrapped.childNodes
           , parent;
-      
+
         if (location === 'prepend') {
           this.insertBefore(wrapped, this.firstChild);
         } else if (location === 'append') {
@@ -240,7 +240,7 @@ tire.fn.extend({
   }
 });
 
-tire.each(['prepend', 'append', 'before', 'after', 'remove'], function (name) {
+tire.each(['prepend', 'append', 'before', 'after', 'remove'], function (index, name) {
   tire.fn[name] = function (name) {
     return function (html) {
       return this.html(html, name);

--- a/src/fn/elements.js
+++ b/src/fn/elements.js
@@ -1,16 +1,16 @@
 tire.fn.extend({
-  
+
   /**
    * Filter element collection
    *
    * @param {String|Function} obj
    * @return {Object}
    */
-  
+
   filter: function (obj) {
     if (tire.isFunction(obj)) {
       var elements = [];
-      this.each(function (elm, index) {
+      this.each(function (index, elm) {
         if (obj.call(elm, index)) {
           elements.push(elm);
         }
@@ -22,27 +22,27 @@ tire.fn.extend({
       });
     }
   },
-  
+
   /**
    * Get elements in list but not with this selector
    *
    * @param {String} selector
    * @return {Object}
    */
-  
+
   not: function (selector) {
     return this.filter(function () {
       return !tire.matches(this, selector);
     });
   },
-  
+
   /**
    * Get the element at position specified by index from the current collection.
    *
    * @param {Integer} index
    * @return {Object}
    */
-  
+
   eq: function (index) {
     return index === -1 ? tire(slice.call(this, this.length -1)) : tire(slice.call(this, index, index + 1));
   },

--- a/src/fn/events.js
+++ b/src/fn/events.js
@@ -36,14 +36,14 @@ function getEventHandlers (id, eventName) {
 function createEventHandler (element, eventName, callback) {
   var id = getEventId(element)
     , handlers = getEventHandlers(id, eventName);
-  
+
   var fn = function (event) {
     if (callback.call(element, event) === false) {
       event.preventDefault();
       event.stopPropagation();
     }
   };
-  
+
   fn.guid = callback.guid = callback.guid || ++_eventId;
   handlers.push(fn);
   return fn;
@@ -60,7 +60,7 @@ function createEventHandler (element, eventName, callback) {
 
 function addEvent (element, eventName, callback) {
   var handler = createEventHandler(element, eventName, callback);
-  
+
   if (element.addEventListener) {
     element.addEventListener(eventName, handler, false);
   } else if (element.attachEvent) {
@@ -80,7 +80,7 @@ function addEvent (element, eventName, callback) {
 function removeEvent (element, eventName, callback) {
   var id = getEventId(element)
     , handlers = getEventHandlers(id, eventName);
-    
+
   for (var i = 0; i < handlers.length; i++) {
     if (callback === undefined || callback.guid === handlers[i].guid) {
       if (element.removeEventListener) {
@@ -93,7 +93,7 @@ function removeEvent (element, eventName, callback) {
       c[id][eventName].remove(i, 1);
     }
   }
-  
+
   delete c[id];
 }
 
@@ -105,7 +105,7 @@ function removeEvent (element, eventName, callback) {
  */
 
 function eachEvent(eventName, callback) {
-  tire.each(eventName.split(' '), function (name) {
+  tire.each(eventName.split(' '), function (index, name) {
     callback(name);
   });
 }
@@ -113,7 +113,7 @@ function eachEvent(eventName, callback) {
 tire.events = tire.events || {};
 
 tire.fn.extend({
-  
+
   /**
    * Add event to element
    *
@@ -121,7 +121,7 @@ tire.fn.extend({
    * @param {Function} callback
    * @return {Object}
    */
-  
+
   on: function (eventName, callback) {
     return this.each(function () {
       var self = this;
@@ -130,7 +130,7 @@ tire.fn.extend({
       });
     });
   },
-  
+
   /**
    * Remove event from element
    *
@@ -138,7 +138,7 @@ tire.fn.extend({
    * @param {Function} callback (optional)
    * @return {Object}
    */
-  
+
   off: function (eventName, callback) {
     return this.each(function () {
       var self = this;
@@ -147,7 +147,7 @@ tire.fn.extend({
       });
     });
   },
-  
+
   /**
    * Trigger specific event for element collection
    *
@@ -155,14 +155,14 @@ tire.fn.extend({
    * @param {Object} data JSON Object to use as the event's `data` property
    * @return {Object}
    */
-  
+
   trigger: function (eventName, data) {
-    return this.each(function (elm) {
+    return this.each(function (index, elm) {
       if (elm === document && !elm.dispatchEvent) elm = document.documentElement;
-  
+
       var event
         , createEvent = !!document.createEvent;
-  
+
       if (createEvent) {
         event = document.createEvent('HTMLEvents');
         event.initEvent(eventName, true, true);
@@ -170,10 +170,10 @@ tire.fn.extend({
         event = document.createEventObject();
         event.cancelBubble = true;
       }
-        
+
       event.data = data || {};
       event.eventName = eventName;
-        
+
       if (createEvent) {
         elm.dispatchEvent(event);
       } else {
@@ -195,5 +195,5 @@ tire.fn.extend({
       }
     });
   }
-  
+
 });

--- a/src/footer.js
+++ b/src/footer.js
@@ -1,4 +1,4 @@
-  
+
   // Expose tire to the global object
   window.$ = window.tire = tire;
 

--- a/test/tests/core-tests.js
+++ b/test/tests/core-tests.js
@@ -48,6 +48,16 @@ test('isWindow', function () {
   ok(!$.isWindow(undefined), 'Should return false for undefined');
 });
 
+test('each', function () {
+  expect(6);
+  var array = ['foo', 'foo'];
+  $.each(array, function(index, element, array){
+    ok(+index === index, true, 'Should return true if 1st param is the index');
+    ok(element === 'foo', true, 'Should return true if 2nd param is the element of the array');
+    ok(array instanceof Array, true, 'Should return true if 3rd param is array');
+  });
+});
+
 test('parseJSON', function () {
   ok(!!($.parseJSON('{"a":"b"}') instanceof Object || !null), true, 'Should parse JSON string to object or return empty string');
 });
@@ -248,9 +258,11 @@ module('Tire attributes.js', {
 });
 
 test('addClass', function () {
+  expect(2);
   $('.test').addClass('dustin');
   equal($('.test').hasClass('dustin'), true, 'Should return true if the element has the class after adding it');
   $('.test').addClass('item-1 item-2 item-3');
+  equal($('.test').attr('class'), 'test dustin item-1 item-2 item-3', 'Should return classes');
 });
 
 test('removeClass', function () {
@@ -379,7 +391,7 @@ if (window.location.protocol.indexOf('http') !== -1 && window.location.search.in
       }
     }
   });
-  
+
   test('get jsonp', function () {
     stop();
     $.ajax('http://echojson.com/hello/world?callback=?&history=false', function (data) {


### PR DESCRIPTION
Callback params are now `index`, `element`, `array`. This means $.each now behaves like the documentation says it should.

Added a unit test for $.each, which was missing.
