### PR TITLE
Prevent context from being overridden when selecting elements using "find"

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -183,12 +183,15 @@ tire.fn = tire.prototype = {
    */
 
   set: function (elements) {
-    var i = 0;
+    // Introduce a fresh `tire` set to prevent context from being overridden
+    var i = 0, newSet = tire();
+    newSet.selector = this.selector;
+    newSet.context = this.context;
     for (; i < elements.length; i++) {
-      this[i] = elements[i];
+      newSet[i] = elements[i];
     }
-    this.length = i;
-    return this;
+    newSet.length = i;
+    return newSet;
   }
 };
 

--- a/src/fn/events.js
+++ b/src/fn/events.js
@@ -39,8 +39,10 @@ function createEventHandler (element, eventName, callback) {
 
   var fn = function (event) {
     if (callback.call(element, event) === false) {
-      event.preventDefault();
-      event.stopPropagation();
+      if (event.stopPropagation) event.stopPropagation();
+      if (event.preventDefault) event.preventDefault();
+      event.cancelBubble = true;
+      event.returnValue = false;
     }
   };
 

--- a/test/tests/core-tests.js
+++ b/test/tests/core-tests.js
@@ -100,6 +100,13 @@ test('Tag name Selector', function () {
   equal(elm.length, 0, 'Should return length 0 for non-existing elemnts in the context');
 });
 
+test('Nested Selector', function () {
+  expect(1);
+  elm = $('ul');
+  elmInner = elm.find('li');
+  equal(elm === elmInner, false, 'Should return false');
+});
+
 test('Elements reference selector', function () {
   expect(3);
   elm = $(document.body);


### PR DESCRIPTION
Came across the following problem the other day:

When selecting elements using the "find" method the result is not as expected. This originates from the "set" method overriding context. Instead, when transforming selected DOM nodes to tire objects, one could use a fresh new tire object, that inherits from context. This makes the find method working as expected. In addition, it also seems to run faster.

To quickly illustrate the problem I created two fiddles:
- "find" as it currently works – not as expected http://jsfiddle.net/jonykrause/6yubE/3/
- "find" working as expected http://jsfiddle.net/jonykrause/ZuKR7/6/

There’s also a test that describes the problem more detailed, see my commit.
Let me know what you think :)
